### PR TITLE
Modify role configuration with bound audiences in 1-setup.sh

### DIFF
--- a/.github/script/1-setup.sh
+++ b/.github/script/1-setup.sh
@@ -27,10 +27,14 @@ EOF
 # Every other workflow configuration in this tutorial is real-world viable, but this
 # is configured solely to allow attendees of this course to authenticate from their
 # clone of this repo - enable a quick win in the first exercise of the course.
+#
+# Vault 1.16.3+ requires bound_audiences when the JWT contains aud (GitHub OIDC always does).
+# Default GitHub aud is the repo owner URL; GITHUB_REPOSITORY_OWNER is set on Actions runners.
 vault write auth/gha/role/hello-world - << EOF
 {
   "role_type": "jwt",
   "user_claim": "actor",
+  "bound_audiences": ["https://github.com/${GITHUB_REPOSITORY_OWNER}"],
   "bound_claims": {
       "iss": "https://token.actions.githubusercontent.com"
   },

--- a/.github/workflows/1-oidc-hello-world.yml
+++ b/.github/workflows/1-oidc-hello-world.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Setup Vault
         env:
           VAULT_ADDR: http://127.0.0.1:8200
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: ./.github/script/1-setup.sh
 
       - name: Retrieve Secrets


### PR DESCRIPTION
Update Vault role configuration to contain bound audiences for GitHub OIDC.

Issue:

`"{"errors":["audience claim found in JWT but no audiences bound to the role"]}"`

Explanation:

On Vault 1.16.3+, JWT login is strict about the aud (audience) claim: if the token includes `aud`, the role must define `bound_audiences`, and at least one entry must match the token.

GitHub’s OIDC JWT always includes `aud`. The hello-world role only has bound_claims, so Vault returns:
audience claim found in JWT but no audiences bound to the role.